### PR TITLE
fritzflash: Add Repeater 300E image auto-selection

### DIFF
--- a/fritzflash.py
+++ b/fritzflash.py
@@ -147,6 +147,7 @@ def autodiscover_avm_ip():
 
 def determine_image_name(env_string):
     models = {
+        "173": "avm-fritz-wlan-repeater-300e-sysupgrade.bin",
         "219": "avm-fritz-box-4020-sysupgrade.bin",
         "227": "avm-fritz-box-4040-bootloader.bin"
     }


### PR DESCRIPTION
Flashing worked just fine.

```
% python fritzflash.py
This program will help you installing Gluon, a widely used Firmware for Freifunk networks, onto your AVM device.
You can always find the most current version of this script at https://www.github.com/freifunk-darmstadt/fritz-tools

It is strongly recommended to only connect your computer to the device you want to flash.
Disable all other connections (Ethernet, WiFi/WLAN)!

Before we start, make sure you have assigned your PC a static IP Address in the Subnet of the device you want to flash.
The following example would be a completely fine option:

IP-Address: 192.168.178.2
Subnet: 255.255.255.0
Gateway: 192.168.178.1
DNS Servers: Leave blank

Once you're done, disconnect power from your AVM device, reconnect the power-supply and press enter.

Trying to autodiscover! Abort via Ctrl-c.
Try 12...
FritzBox found at 192.168.178.1

Autodiscovery succesful!
-> Device detected at 192.168.178.1.

Starting automatic image-selection!
-> Establishing connection to device!
--> Try 1 of 10
--> Try 2 of 10
-> Automatic image-selection successful!
--> Will flash /tmp/gluon-ffda-1.3~20181222-avm-fritz-wlan-repeater-300e-sysupgrade.bin
-> Establishing connection to device!
--> Try 1 of 10
-> Flash image

Writing Gluon image to your AVM device...
This process may take a lot of time.

First, the device will erase it's current Operating System.
Next, the device will write the Gluon image to it's memory.
The red Info LED will illuminate in this step. Don't worry, this is expected behavior.

Do *not* turn of the device!

We will tell you when your device has finished installing Gluon (this may take a while).
-> Image write successful
-> Performing reboot

== Congratulations! ==

Your device is now running Gluon.
It will restart and in 2-5 minutes you will be able to visit it's config-mode.
Remember to reconfigure your interface to automatically obtain an IP-address!
You can reach config-mode by typing in http://192.168.1.1/ in your preferred Webbrowser.

Press any key to exit.
```

The env looks like this:
```
HWRevision            173
HWSubRevision         2
ProductID             Fritz_Box_Neon
SerialNumber          0000000000000000
annex                 Ohne
autoload              yes
bootloaderVersion     1.1183
bootserport           tty0
cpufrequency          400000000
crash                 [0]206d508e,5b2d3cd7,1[1]0,0,0[2]0,0,0[3]0,0,0
firstfreeaddress      0x810D7C10
firmware_info         101.06.30
firmware_version      avm
flashsize             nor_size=0x0 sflash_size=16MB nand_size=0MB
maca                  C0:25:06:63:36:AF
macb                  C0:25:06:63:36:B0
macwlan               C0:25:06:63:36:B1
macdsl                C0:25:06:63:36:B2
memsize               0x04000000
modetty0              38400,n,8,1,hw
modetty1              38400,n,8,1,hw
mtd1                  0x9F020000,0x9FF00000
mtd2                  0x9F000000,0x9F020000
mtd3                  0x9FF00000,0x9FF80000
mtd4                  0x9FF80000,0xA0000000
my_ipaddress          192.168.178.1
prompt                Eva_AVM
req_fullrate_freq     200000000
sysfrequency          200000000
urlader-version       2183
usb_board_mac         C0:25:06:63:36:B3
usb_device_id         0x0000
usb_device_name       USB DSL Device
usb_manufacturer_name  AVM
usb_revision_id       0x0000
usb_rndis_mac         C0:25:06:63:36:B4
wlan_key              00000000
```