### PR TITLE
 fritzflash: add support for FRITZ!Box 7360 (v1, v2) and 7360 SL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,8 @@ These devices are confirmed working using the tools provided in this repository.
  - FRITZ!Box 4020
  - FRITZ!Box 4040
  - FRITZ!Box 7312
+ - FRITZ!Box 7360 (v1, v2)
+ - FRITZ!Box 7360 SL
  - FRITZ!WLAN Repeater 300E
  - FRITZ!WLAN Repeater 450E
  - FRITZ!WLAN Repeater 1750E

--- a/fritzflash.py
+++ b/fritzflash.py
@@ -156,12 +156,36 @@ def determine_image_name(env_string):
                 "fritz300e-squashfs-sysupgrade.bin"
             ],
         },
+        "181": {
+            "gluon": [
+                "avm-fritz-box-7360-sl-sysupgrade.bin"
+            ],
+            "openwrt": [
+                "avm_fritz7360sl-squashfs-sysupgrade.bin"
+            ],
+        },
+        "183": {
+            "gluon": [
+                "avm-fritz-box-7360-v1-sysupgrade.bin"
+            ],
+            "openwrt": [
+                "avm_fritz7360sl-squashfs-sysupgrade.bin"
+            ],
+        },
         "189": {
             "gluon": [
                 "avm-fritz-box-7312-sysupgrade.bin"
             ],
             "openwrt": [
                 "avm_fritz7312-squashfs-sysupgrade.bin"
+            ],
+        },
+        "196": {
+            "gluon": [
+                "avm-fritz-box-7360-v2-sysupgrade.bin"
+            ],
+            "openwrt": [
+                "avm_fritz7360sl-squashfs-sysupgrade.bin"
             ],
         },
         "200": {


### PR DESCRIPTION
AVM FRITZ!Box 7360 v1, v2 and 7360 SL are Hardware Identical except the flash size for v2 and no POTS on SL. OpenWRT works with all.