### PR TITLE
fritzflash: add support for FRITZ!Box 7320, 7330 and 7330 SL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,9 @@ These devices are confirmed working using the tools provided in this repository.
  - FRITZ!Box 4020
  - FRITZ!Box 4040
  - FRITZ!Box 7312
+ - FRITZ!Box 7320
+ - FRITZ!Box 7330
+ - FRITZ!Box 7330 SL
  - FRITZ!Box 7360 (v1, v2)
  - FRITZ!Box 7360 SL
  - FRITZ!WLAN Repeater 300E

--- a/fritzflash.py
+++ b/fritzflash.py
@@ -148,12 +148,28 @@ def autodiscover_avm_ip():
 
 def determine_image_name(env_string):
     models = {
+        "172": {
+            "gluon": [
+                "avm-fritz-box-7320-sysupgrade.bin"
+            ],
+            "openwrt": [
+                "avm_fritz7320-squashfs-sysupgrade.bin"
+            ],
+        },
         "173": {
             "gluon": [
                 "avm-fritz-wlan-repeater-300e-sysupgrade.bin"
             ],
             "openwrt": [
                 "fritz300e-squashfs-sysupgrade.bin"
+            ],
+        },
+        "179": {
+            "gluon": [
+                "avm-fritz-box-7330-sysupgrade.bin"
+            ],
+            "openwrt": [
+                "avm_fritz7320-squashfs-sysupgrade.bin"
             ],
         },
         "181": {
@@ -170,6 +186,14 @@ def determine_image_name(env_string):
             ],
             "openwrt": [
                 "avm_fritz7360sl-squashfs-sysupgrade.bin"
+            ],
+        },
+        "188": {
+            "gluon": [
+                "avm-fritz-box-7330-sl-sysupgrade.bin"
+            ],
+            "openwrt": [
+                "avm_fritz7320-squashfs-sysupgrade.bin"
             ],
         },
         "189": {


### PR DESCRIPTION
AVM FRITZ!Box 7320, 7330 and 7330 SL are Hardware Identical except no POTS on the SL variant. The OpenWRT Image for 7320 works with all of them.