### PR TITLE
Send probes  more aggressively

### DIFF
--- a/fritzflash.py
+++ b/fritzflash.py
@@ -146,7 +146,7 @@ def autodiscover_avm_ip():
             i += 1
         except OSError:
             i += 1
-            time.sleep(1)
+            time.sleep(0.1)
         except KeyboardInterrupt:
             print('\rAborting...\n')
             return None


### PR DESCRIPTION
Sending probes every second is to slow. The original revovery tool is probing
with a frequency of 0.5 seconds. This patch changes probe frequency to 0.1
seconds.